### PR TITLE
Exit successfully when encountered EOF

### DIFF
--- a/roogle/src/main.rs
+++ b/roogle/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
                     println!("{:?}", item.name);
                 }
             }
-            Err(ReadlineError::Interrupted) => break,
+            Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => break,
             _ => panic!("exitted repl"),
         }
     }


### PR DESCRIPTION
## 概要

EOF を入力したときに CLI が異常終了するようになっている影響で、

- パイプで入力を与えたとき
- 入力待ち状態で `Ctrl + D` を入力したとき

に panic! してしまうのを修正しました。

## 変更前の挙動

```bash
% echo "fn (Option<T>) -> bool" | cargo run -- --index assets/core.json
   Compiling roogle v0.1.3 (/Users/kodai/github/roogle/roogle)
    Finished dev [unoptimized + debuginfo] target(s) in 5.74s
     Running `target/debug/roogle --index assets/core.json`
Some("is_none")
Some("is_some")
Some("is_empty")
thread 'main' panicked at 'exitted repl', roogle/src/main.rs:48:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

% echo $?
101
```

## 変更後の挙動

```bash
% echo "fn (Option<T>) -> bool" | cargo run -- --index assets/core.json
   Compiling roogle v0.1.3 (/Users/kodai/github/roogle/roogle)
    Finished dev [unoptimized + debuginfo] target(s) in 5.17s
     Running `target/debug/roogle --index assets/core.json`
Some("is_none")
Some("is_some")
Some("is_empty")

% echo $?
0
```